### PR TITLE
luci-app-mosdns: fix an error reported when using imageBuilder

### DIFF
--- a/luci-app-mosdns/Makefile
+++ b/luci-app-mosdns/Makefile
@@ -17,6 +17,7 @@ endef
 
 define Package/$(PKG_NAME)/postinst
 #!/bin/sh
+[ ! -f /etc/openwrt_release ] && exit 0
 [ -n "${IPKG_INSTROOT}" ] || {
 	sysctl -p /etc/sysctl.d/20-mosdns-buffer-increase.conf
 	exit 0

--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -20,6 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+[ ! -f /etc/openwrt_release ] && exit 0
+
 START=99
 USE_PROCD=1
 


### PR DESCRIPTION
When using immortalwrt Image Builder to compile luci-app-mosdns, some errors will be prompted like:

```
sysctl: cannot open "/etc/sysctl.d/20-mosdns-buffer-increase.conf": No such file or directory
```
```
/home/helloworld/immortalwrt/immortalwrt-imagebuilder-23.05.0-rc2-x86-64.Linux-x86_64/build_dir/target-x86_64_musl/root-x86/etc/init.d/mosdns: line 27: uci: command not found
```

Reference：https://github.com/vernesong/OpenClash/issues/1930