### PR TITLE
mosdns: add Checksum for geoip/geosite update

### DIFF
--- a/luci-app-mosdns/root/usr/share/mosdns/mosdns.sh
+++ b/luci-app-mosdns/root/usr/share/mosdns/mosdns.sh
@@ -71,10 +71,30 @@ geodat_update() (
     echo -e "\e[1;32mDownloading "$mirror"https://github.com/Loyalsoldier/geoip/releases/latest/download/geoip-only-cn-private.dat\e[0m"
     curl --connect-timeout 60 -m 900 --ipv4 -kfSLo "$TMPDIR/geoip.dat" ""$mirror"https://github.com/Loyalsoldier/geoip/releases/latest/download/geoip-only-cn-private.dat"
     [ $? -ne 0 ] && rm -rf "$TMPDIR" && exit 1
+    # checksum - geoip.dat
+    echo -e "\e[1;32mDownloading "$mirror"https://github.com/Loyalsoldier/geoip/releases/latest/download/geoip-only-cn-private.dat.sha256sum\e[0m"
+    curl --connect-timeout 60 -m 900 --ipv4 -kfSLo "$TMPDIR/geoip.dat.sha256sum" ""$mirror"https://github.com/Loyalsoldier/geoip/releases/latest/download/geoip-only-cn-private.dat.sha256sum"
+    [ $? -ne 0 ] && rm -rf "$TMPDIR" && exit 1
+    if [ "$(sha256sum "$TMPDIR/geoip.dat" | awk '{print $1}')" != "$(cat "$TMPDIR/geoip.dat.sha256sum" | awk '{print $1}')" ]; then
+        echo -e "\e[1;31mgeoip.dat checksum error\e[0m"
+        rm -rf "$TMPDIR"
+        exit 1
+    fi
+
     # geosite.dat
     echo -e "\e[1;32mDownloading "$mirror"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat\e[0m"
     curl --connect-timeout 60 -m 900 --ipv4 -kfSLo "$TMPDIR/geosite.dat" ""$mirror"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat"
     [ $? -ne 0 ] && rm -rf "$TMPDIR" && exit 1
+    # checksum - geosite.dat
+    echo -e "\e[1;32mDownloading "$mirror"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat.sha256sum\e[0m"
+    curl --connect-timeout 60 -m 900 --ipv4 -kfSLo "$TMPDIR/geosite.dat.sha256sum" ""$mirror"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat.sha256sum"
+    [ $? -ne 0 ] && rm -rf "$TMPDIR" && exit 1
+    if [ "$(sha256sum "$TMPDIR/geosite.dat" | awk '{print $1}')" != "$(cat "$TMPDIR/geosite.dat.sha256sum" | awk '{print $1}')" ]; then
+        echo -e "\e[1;31mgeosite.dat checksum error\e[0m"
+        rm -rf "$TMPDIR"
+        exit 1
+    fi
+    rm -rf "$TMPDIR"/*.sha256sum
     cp -f "$TMPDIR"/* /usr/share/v2ray
     rm -rf "$TMPDIR"
 )


### PR DESCRIPTION
When network conditions are bad, a corrupted file may be saved, causing some errors, and `[ $? -ne 0 ]` does not catch these problems
Need to add checksum to verify file integrity
Error log:
```
2023-06-22T14:03:06.992Z	FATAL	failed to unpack geoip	{"error": "proto: cannot parse invalid wire-format data"}
github.com/urlesistiana/v2dat/cmd/unpack.newGeoIPCmd.func1
	github.com/urlesistiana/v2dat/cmd/unpack/geoip.go:25
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.6.1/command.go:920
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.6.1/command.go:1044
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.6.1/command.go:968
main.main
	github.com/urlesistiana/v2dat/main.go:9
runtime.main
	runtime/proc.go:250
2023-06-22T14:03:06.995Z	FATAL	failed to unpack geosite	{"error": "proto: cannot parse invalid wire-format data"}
github.com/urlesistiana/v2dat/cmd/unpack.newGeoSiteCmd.func1
	github.com/urlesistiana/v2dat/cmd/unpack/geosite.go:30
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.6.1/command.go:920
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.6.1/command.go:1044
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.6.1/command.go:968
main.main
	github.com/urlesistiana/v2dat/main.go:9
runtime.main
	runtime/proc.go:250
```