### PR TITLE
mosdns: upgrade compress to v1.17.0

### DIFF
--- a/mosdns/patches/100-update-dependencies.patch
+++ b/mosdns/patches/100-update-dependencies.patch
@@ -28,7 +28,7 @@ index 2212cd3..b56078b 100644
  	github.com/kardianos/service v1.2.2
 -	github.com/klauspost/compress v1.16.3
 -	github.com/miekg/dns v1.1.52
-+	github.com/klauspost/compress v1.16.7
++	github.com/klauspost/compress v1.17.0
 +	github.com/miekg/dns v1.1.56
  	github.com/mitchellh/mapstructure v1.5.0
  	github.com/nadoo/ipset v0.5.0
@@ -180,8 +180,8 @@ index 960ad98..633f864 100644
  github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 -github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
 -github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
-+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
-+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
++github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
++github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
  github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
  github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 -github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=


### PR DESCRIPTION
fix: https://github.com/sbwml/luci-app-mosdns/issues/122