### PR TITLE
luci-app-mosdns: fix query_is_apple_domain

### DIFF
--- a/luci-app-mosdns/root/usr/share/mosdns/default.yaml
+++ b/luci-app-mosdns/root/usr/share/mosdns/default.yaml
@@ -179,8 +179,9 @@ plugins:
   - tag: query_is_apple_domain
     type: sequence
     args:
-      - matches: qname $geosite_apple
-        exec: $forward_dnspod_udp
+      - matches: "!qname $geosite_apple"
+        exec: return
+      - exec: $forward_local
       - matches: "!resp_ip $geoip_cn"
         exec: drop_resp
       - matches: "!has_resp"


### PR DESCRIPTION
原来代码这里一定会有返回值，导致开启了“Apple 域名解析优化”之后，不会走后面的流程了。
这次提交有两个修改：
1、先判断是否apple域名，非apple域名直接返回；
2、优先使用`local_dns`解析