### PR TITLE
fix: skip dnsmasq reload when dnsmasq is not enabled

### DIFF
--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -720,6 +720,7 @@ redirect_setting() {
 }
 
 reload_dnsmasq() {
+	[ -z "$(/etc/init.d/dnsmasq enabled 2>&1)" ] && return 0
 	/etc/init.d/dnsmasq reload
 }
 


### PR DESCRIPTION
## Summary

When dnsmasq is disabled (not enabled), mosdns should not attempt to reload it. This prevents unnecessary service restarts and potential conflicts when using AdGuard Home as the primary DNS server.

## Changes

- Added check in `reload_dnsmasq()` function to skip reload when dnsmasq is not enabled

## Test plan

- [ ] Verify mosdns start/stop does not trigger dnsmasq reload when dnsmasq is disabled
- [ ] Verify mosdns still reloads dnsmasq correctly when dnsmasq is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)